### PR TITLE
chore: add kill-servers.sh script to clean left behind processes

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@
 
 ### How-to
 
+#### ...fix "Port XXXX is already in use." error
+
+```sh
+./scripts/kill-servers.sh
+```
+
 #### ...run the projects in dev mode
 
 ```sh

--- a/scripts/kill-servers.sh
+++ b/scripts/kill-servers.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env zsh
+
+_kill_process_listening_at() {
+    _PORT="$1"
+    _PID="$(lsof -i ":$_PORT" -S | grep LISTEN | awk '{print $2}')"
+    if [ -n "$_PID" ]; then
+        echo "Killing process $_PID which was listening to port $_PORT"
+        kill -9 "$_PID"
+    fi
+}
+
+_kill_process_listening_at 3000
+_kill_process_listening_at 3001
+_kill_process_listening_at 6006
+
+echo "Done!"


### PR DESCRIPTION
This PR adds a script to automatically kill processes left behind by the repository's servers. Useful when receiving the error "Port XXXX is already in use".